### PR TITLE
test case 0 should run less jankly now

### DIFF
--- a/flow.py
+++ b/flow.py
@@ -1,3 +1,8 @@
+from math import ceil
+from pqueue import event_queue, enqueue
+import packet
+import event
+
 class Flow:
 
     f_map = {}
@@ -6,6 +11,7 @@ class Flow:
         self.id = flow_id
         self.source = source
         self.destination = destination
+        # Data_amnt is in megabytes.
         self.data_amt = data_amt
         self.start_time = start_time
 
@@ -15,3 +21,15 @@ class Flow:
             str(self.data_amt) + ", Start time: " + str(self.start_time) + ">"
 
     __repr__ = __str__
+
+    def startFlow(self):
+        # Figure out how many packets to send.
+        # This is a fixed amount P = data_amt/pkt_size
+        # Where pkt_size is 1024 bytes.
+
+        # =====TODO: put PACKET_SIZE as a global variable for reference?====
+
+        num_packets = (int)(ceil(self.data_amt * 1.0e6 / 1024))
+        for i in range(num_packets):
+            pkt = packet.Packet(self.source, self.destination, i)
+            enqueue(event.SendPacket(1, pkt, self.source.link))

--- a/main.py
+++ b/main.py
@@ -1,36 +1,46 @@
+import sys
 from pqueue import event_queue, enqueue, dequeue, qempty
 import event
 import link
 import host
 import packet
+import flow
 
 from parser import parse
 
-time = 0
 
-# Parser Configuration
-TEST_CASE = '1'
-INFILE = './input/test_case_' + TEST_CASE
+if __name__ == "__main__":
+	# Read arguments to figure out what test case
+	TEST_CASE = sys.argv[1]
+	time = 0
 
-# Lists of each object returned from the parser
-hosts, links, flows, routers = parse(INFILE)
+	# Parser Configuration
+	INFILE = './input/test_case_' + TEST_CASE
 
-# Test case -1
-l1 = link.Link('L1', 10, 10, [])
-h1 = host.Host('H1', l1)
-h2 = host.Host('H2', l1)
+	# Lists of each object returned from the parser
+	links, hosts, routers, flows = parse(INFILE)
 
-for i in "THIS IS A MESSAGE":
-    pkt = packet.Packet(h1, h2, i)
-    enqueue(event.SendPacket(1, pkt, h1.link))
-# END TEST CASE -1 ===================================
+	for flow in flows:
+		flow.startFlow()
 
-while (qempty() == False):
-    event = dequeue()
-    time = event.start_time
-    event.process()
+	'''
+	# ============ Test case -1 ======================
+	l1 = link.Link('L1', 10, 10, [])
+	h1 = host.Host('H1', l1)
+	h2 = host.Host('H2', l1)
 
-print (time)
+	for i in "THIS IS A MESSAGE":
+	    pkt = packet.Packet(h1, h2, i)
+	    enqueue(event.SendPacket(1, pkt, h1.link))
+	# END TEST CASE -1 ===================================
+	'''
+
+	while (qempty() == False):
+	    event = dequeue()
+	    time = event.start_time
+	    event.process()
+
+	print (time)
 '''
 trash
 

--- a/parser.py
+++ b/parser.py
@@ -143,10 +143,10 @@ def parse_links(f):
         link_id = next_line(f)
         # print link_id
 
-        link_rate = next_line(f)
+        link_rate = next_line(f, 'f')
         # print link_rate
 
-        link_delay = next_line(f)
+        link_delay = next_line(f, 'f')
         # print link_delay
 
         link_buffer_size = next_line(f)
@@ -188,10 +188,10 @@ def parse_flows(f, h_map):
         dest_host = h_map[flow_dest]
         # print dest_host
 
-        data_amount = next_line(f)
+        data_amount = next_line(f, 'i')
         # print data_amount
 
-        flow_start_time = next_line(f)
+        flow_start_time = next_line(f, 'f')
         # print flow_start_time
 
         f = flow_class.Flow(flow_id, src_host, dest_host, 


### PR DESCRIPTION
1. Main loop now takes an argument (which test case we're simulating: 0, 1, 2)
2. Flow class now calculates how many packets it needs to break its data flow into. It creates these packets and enqueues them all into the global queue. It doesn't have a window W or any congestion control yet.
3. Parser passes integers and floats into class variables that should be integers or floats now.

==

Since test case 0 sends a data stream of 20MB, and we print packet contents whenever we receive a packet at a host, when you try to run it right now theres a flood of numbers on ur terminal screen n it sucks. Might want to just produce a plot at the end.