### PR TITLE
flow window + misc changes (see description)

### DIFF
--- a/flow.py
+++ b/flow.py
@@ -1,5 +1,5 @@
 from math import ceil
-from pqueue import event_queue, enqueue
+from pqueue import event_queue, enqueue, get_global_time, qempty
 import packet
 import event
 
@@ -15,6 +15,10 @@ class Flow:
         self.data_amt = data_amt
         self.start_time = start_time
 
+        self.window_size = 100
+        self.curr_pkt = 0
+        self.num_packets = int(ceil(data_amt * 1.0e6 / packet.DataPkt.PACKET_SIZE))
+
 
     def __str__(self):
         return "<Flow ID: " + str(self.id) + ", Source: " + str(self.source) +  \
@@ -29,9 +33,23 @@ class Flow:
         # Where pkt_size is 1024 bytes.
 
         # =====TODO: put PACKET_SIZE as a global variable for reference?====
+        while (self.curr_pkt < min(self.num_packets, self.window_size)):
+            pkt = packet.DataPkt(self.source, self.destination, \
+                "PACKET %d" % self.curr_pkt, self.curr_pkt, self)
+            enqueue(event.SendPacket(self.start_time, pkt, \
+                self.source.link, self.source))
+            self.curr_pkt += 1
 
-        num_packets = int(ceil(self.data_amt * 1.0e6 / packet.Packet.PACKET_SIZE))
-
+        '''
         for i in range(num_packets):
             pkt = packet.Packet(self.source, self.destination, i, i)
             enqueue(event.SendPacket(1, pkt, self.source.link, self.source))
+        '''
+    def receiveAck(self, ack, curr_time):
+        if (self.curr_pkt < self.num_packets):
+            pkt = packet.DataPkt(self.source, self.destination, \
+                "PACKET %d" % self.curr_pkt, self.curr_pkt, self)
+            enqueue(event.SendPacket(curr_time, pkt, self.source.link, self.source))
+            self.curr_pkt += 1
+
+

--- a/flow.py
+++ b/flow.py
@@ -33,5 +33,5 @@ class Flow:
         num_packets = int(ceil(self.data_amt * 1.0e6 / packet.Packet.PACKET_SIZE))
 
         for i in range(num_packets):
-            pkt = packet.Packet(self.source, self.destination, i)
+            pkt = packet.Packet(self.source, self.destination, i, i)
             enqueue(event.SendPacket(1, pkt, self.source.link, self.source))

--- a/host.py
+++ b/host.py
@@ -42,7 +42,7 @@ class Host:
         if (isinstance(pkt, packet.Ack)):
             return
 
-        ack = packet.Ack(self, pkt.sender)
+        ack = packet.Ack(self, pkt.sender, pkt.number)
         enqueue(event.SendPacket(time, ack, self.link, self))
 
     def __str__(self):

--- a/host.py
+++ b/host.py
@@ -40,10 +40,13 @@ class Host:
     def receive(self, pkt, time):
         print (pkt.payload, time)
         if (isinstance(pkt, packet.Ack)):
-            return
-
-        ack = packet.Ack(self, pkt.sender, pkt.number)
-        enqueue(event.SendPacket(time, ack, self.link, self))
+            pkt.flow.receiveAck(pkt, time)
+        
+        else:
+            #ack = packet.Ack(self, pkt.sender, pkt.number)
+            ack = packet.makeAck(pkt)
+            enqueue(event.SendPacket(time, ack, self.link, self))
+            
 
     def __str__(self):
         return "<Host ID: " + str(self.id) + ", Address: " + str(self.address) +  \

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import sys
-from pqueue import event_queue, enqueue, dequeue, qempty
+from pqueue import event_queue, enqueue, dequeue, qempty, set_global_time
 import event
 import link
 import host
@@ -17,7 +17,6 @@ if __name__ == "__main__":
     
     # Read arguments to figure out what test case
     TEST_CASE = sys.argv[1]
-    time = 0
 
     # Parser Configuration
     INFILE = './input/test_case_' + TEST_CASE
@@ -51,10 +50,10 @@ if __name__ == "__main__":
 
     while (qempty() == False):
         event = dequeue()
-        time = event.start_time
+        set_global_time(event.start_time)
         event.process()
 
-    print (time)
+    print ("SIMULATION END")
 '''
 trash
 

--- a/packet.py
+++ b/packet.py
@@ -1,10 +1,11 @@
 class Packet(object):
     PACKET_SIZE = 1024
-    def __init__(self, sender, recipient, payload, size=PACKET_SIZE):
+    def __init__(self, sender, recipient, payload, number, size=PACKET_SIZE):
         self.size = size
         self.sender = sender
         self.recipient = recipient
         self.payload = payload
+        self.number = number
 
     def NewPacket(self, meta, payload):
         ''' If this is really necessary '''
@@ -18,5 +19,5 @@ class Ack(Packet):
     # Inheritance syntax from
     # Source: http://stackoverflow.com/questions/9698614/
     #         super-raises-typeerror-must-be-type-not-classobj-for-new-style-class
-    def __init__(self, sender, recipient):
-        super(self.__class__, self).__init__(sender, recipient, "ACK", Ack.ACK_SIZE)
+    def __init__(self, sender, recipient, number):
+        super(self.__class__, self).__init__(sender, recipient, "ACK", number, Ack.ACK_SIZE)

--- a/packet.py
+++ b/packet.py
@@ -1,11 +1,12 @@
 class Packet(object):
     PACKET_SIZE = 1024
-    def __init__(self, sender, recipient, payload, number, size=PACKET_SIZE):
+    def __init__(self, sender, recipient, payload, number, size, flow):
         self.size = size
         self.sender = sender
         self.recipient = recipient
         self.payload = payload
         self.number = number
+        self.flow = flow
 
     def NewPacket(self, meta, payload):
         ''' If this is really necessary '''
@@ -19,5 +20,15 @@ class Ack(Packet):
     # Inheritance syntax from
     # Source: http://stackoverflow.com/questions/9698614/
     #         super-raises-typeerror-must-be-type-not-classobj-for-new-style-class
-    def __init__(self, sender, recipient, number):
-        super(self.__class__, self).__init__(sender, recipient, "ACK", number, Ack.ACK_SIZE)
+    def __init__(self, sender, recipient, number, flow):
+        super(self.__class__, self).__init__(sender, recipient, \
+            "ACK %d" % number, number, Ack.ACK_SIZE, flow)
+
+def makeAck(pkt):
+    return Ack(pkt.recipient, pkt.sender, pkt.number, pkt.flow)
+
+class DataPkt(Packet):
+    PACKET_SIZE = 1024
+    def __init__(self, sender, recipient, payload, number, flow):
+        super(self.__class__, self).__init__(sender, recipient, payload, \
+            number, DataPkt.PACKET_SIZE, flow)

--- a/pqueue.py
+++ b/pqueue.py
@@ -15,6 +15,7 @@ Functions:
 '''
 
 event_queue = Queue.PriorityQueue()
+global_time = 0
 
 def enqueue(evt):
     event_queue.put((evt.start_time, evt.priority, evt))
@@ -25,3 +26,9 @@ def dequeue():
 
 def qempty():
     return event_queue.empty()
+
+def set_global_time(t):
+    global_time = t
+
+def get_global_time():
+    return global_time


### PR DESCRIPTION
Basic implementation of a flow packet-sending window size + some formatting changes/class restructuring that arose because apparently things bother me when I code at 6:30AM.

Summary of changes:
- Flows now have num_packets as a field, along with window_size and curr_pkt (which represents the next packet to send). 
  - The "curr_pkt" implementation will probably have to change when we start adding timeouts/accounting for unreceived packets
- startFlow pretty much sends as many packets as the window size / number of packets will allow
- Flows now have receiveAck methods. When hosts receive ACK packets, they pass the ACK to the flow via receiveAck, and right now the flow just sends the next packet if there is a next packet.
  - At some point later we'll probably have to do some packet-received checking
- The current result of this is that we can send all of test case 1 if window size is pretty small, and everything after the first window_size packets is received in order.

Formatting/class changes:
- Packets now take a flow parameter. This is pretty much which flow the packet is relevant to
- There's a separate DataPkt --i.e. non-Ack Packets-- class (pretty much what we were previously using the parent Packet class for). I pmuch got tired of dealing with the base class and wanted to clean things up a bit.
- Global time has been put into the pqueue module, with accessing + setting methods